### PR TITLE
Fix issue #4: Change 'Voice to YouTube' title to 'TalkTube' and add YouTube icon

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,21 +1,27 @@
 'use client'
 
-import {
-  Mic,
-  Users,
-  BotIcon as Robot,
-  Podcast,
-  Radio,
-  Image,
-  Youtube,
-} from 'lucide-react'
+import { Mic, Podcast, Radio, Image } from 'lucide-react'
 import FeatureCard from '@/components/FeatureCard'
 
 const features = [
   {
     href: '/voice-to-youtube',
-    icon: Youtube,
-    title: 'Voice-To-YouTube',
+    icon: (props) => (
+      <svg
+        xmlns='http://www.w3.org/2000/svg'
+        viewBox='0 0 24 24'
+        fill='none'
+        stroke='currentColor'
+        strokeWidth='2'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+        {...props}
+      >
+        <path d='M2.5 17a24.12 24.12 0 0 1 0-10 2 2 0 0 1 1.4-1.4 49.56 49.56 0 0 1 16.2 0A2 2 0 0 1 21.5 7a24.12 24.12 0 0 1 0 10 2 2 0 0 1-1.4 1.4 49.55 49.55 0 0 1-16.2 0A2 2 0 0 1 2.5 17' />
+        <path d='m10 15 5-3-5-3z' />
+      </svg>
+    ),
+    title: 'TalkTube',
     description: 'Search YouTube Videos',
     subDescription: 'Web Embed Example',
   },

--- a/components/YouTubePlayer.jsx
+++ b/components/YouTubePlayer.jsx
@@ -72,12 +72,25 @@ export default function YouTubePlayer() {
   return (
     <div className='min-h-screen bg-[#1e293b] p-4 md:p-8'>
       <motion.h1
-        className='text-4xl font-bold text-center text-orange-500 mb-8'
+        className='text-4xl font-bold text-center text-orange-500 mb-8 flex items-center justify-center gap-2'
         initial={{ opacity: 0, y: -50 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
       >
-        Voice to YouTube
+        <svg
+          xmlns='http://www.w3.org/2000/svg'
+          viewBox='0 0 24 24'
+          fill='none'
+          stroke='currentColor'
+          strokeWidth='2'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+          className='w-8 h-8'
+        >
+          <path d='M2.5 17a24.12 24.12 0 0 1 0-10 2 2 0 0 1 1.4-1.4 49.56 49.56 0 0 1 16.2 0A2 2 0 0 1 21.5 7a24.12 24.12 0 0 1 0 10 2 2 0 0 1-1.4 1.4 49.55 49.55 0 0 1-16.2 0A2 2 0 0 1 2.5 17' />
+          <path d='m10 15 5-3-5-3z' />
+        </svg>{' '}
+        TalkTube
       </motion.h1>
       <motion.p
         className='text-xl font-semibold text-center text-white mb-4'


### PR DESCRIPTION
This PR addresses issue #4 by:

1. Changing the title from 'Voice to YouTube' to 'TalkTube' in the YouTubePlayer component
2. Adding a YouTube icon next to the title
3. Updating the feature card title in the homepage

The deprecated Lucide React YouTube icon was replaced with an inline SVG to avoid deprecation warnings.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - The "Voice-To-YouTube" feature has been refreshed and rebranded as "TalkTube" with a custom icon.
  - The header now boasts improved alignment and spacing, presenting the new icon alongside the "TalkTube" label for a more polished visual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->